### PR TITLE
Fix the paths of static ICU libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ PKGCONFIG_DEPS = freetype2 gl glu glew xaw7 zlib zziplib xrandr xrender
 
 
 ICU_LDLIBS= \
-    /usr/lib/x86_64-linux-gnu/libicui18n.a \
-    /usr/lib/x86_64-linux-gnu/libicuuc.a \
-    /usr/lib/x86_64-linux-gnu/libicudata.a \
+    /usr/lib/libicui18n.a \
+    /usr/lib/libicuuc.a \
+    /usr/lib/libicudata.a \
     -ldl \
 
 OPENAL_LDLIBS   ?= -lopenal -lvorbisfile


### PR DESCRIPTION
The new path is the right path on at least Ubuntu Precise
(http://packages.ubuntu.com/precise/amd64/libicu-dev/filelist) and Arch Linux
(https://aur.archlinux.org/packages/icu-staticlibs/).