### PR TITLE
temporary local fix for gcc isnan error

### DIFF
--- a/engine/lua_wrappers_core.cpp
+++ b/engine/lua_wrappers_core.cpp
@@ -25,15 +25,6 @@
     #include <google/profiler.h>
 #endif
 
-#ifndef isnan
-        static inline bool isnan(float f)
-        {
-            // std::isnan() is C99, not supported by all compilers
-            // However NaN always fails this next test, no other number does.
-            return f != f;
-        }
-#endif
-
 #ifndef WIN32
     #include <sys/mman.h>
 #endif
@@ -723,7 +714,7 @@ TRY_START
         float w, x, y, z;
         switch (lua_type(L, i)) {
             case LUA_TNUMBER:
-            if (isnan(lua_tonumber(L, i))) {
+            if (std::isnan(lua_tonumber(L, i))) {
                 msg << "Got NaN in number, index " << i;
                 my_lua_error(L, msg.str());
             }
@@ -731,11 +722,11 @@ TRY_START
 
             case LUA_TVECTOR2:
             lua_checkvector2(L, i, &x, &y);
-            if (isnan(x)) {
+            if (std::isnan(x)) {
                 msg << "Got NaN in vec2 x coord, index " << i;
                 my_lua_error(L, msg.str());
             }
-            if (isnan(y)) {
+            if (std::isnan(y)) {
                 msg << "Got NaN in vec2 y coord, index " << i;
                 my_lua_error(L, msg.str());
             }
@@ -743,15 +734,15 @@ TRY_START
 
             case LUA_TVECTOR3:
             lua_checkvector3(L, i, &x, &y, &z);
-            if (isnan(x)) {
+            if (std::isnan(x)) {
                 msg << "Got NaN in vec3 x coord, index " << i;
                 my_lua_error(L, msg.str());
             }
-            if (isnan(y)) {
+            if (std::isnan(y)) {
                 msg << "Got NaN in vec3 y coord, index " << i;
                 my_lua_error(L, msg.str());
             }
-            if (isnan(z)) {
+            if (std::isnan(z)) {
                 msg << "Got NaN in vec3 z coord, index " << i;
                 my_lua_error(L, msg.str());
             }
@@ -759,19 +750,19 @@ TRY_START
 
             case LUA_TVECTOR4:
             lua_checkvector4(L, i, &x, &y, &z, &w);
-            if (isnan(x)) {
+            if (std::isnan(x)) {
                 msg << "Got NaN in vec4 x coord, index " << i;
                 my_lua_error(L, msg.str());
             }
-            if (isnan(y)) {
+            if (std::isnan(y)) {
                 msg << "Got NaN in vec4 y coord, index " << i;
                 my_lua_error(L, msg.str());
             }
-            if (isnan(z)) {
+            if (std::isnan(z)) {
                 msg << "Got NaN in vec4 z coord, index " << i;
                 my_lua_error(L, msg.str());
             }
-            if (isnan(w)) {
+            if (std::isnan(w)) {
                 msg << "Got NaN in vec4 w coord, index " << i;
                 my_lua_error(L, msg.str());
             }
@@ -779,19 +770,19 @@ TRY_START
 
             case LUA_TQUAT:
             lua_checkquat(L, i, &x, &y, &z, &w);
-            if (isnan(w)) {
+            if (std::isnan(w)) {
                 msg << "Got NaN in quat w coord, index " << i;
                 my_lua_error(L, msg.str());
             }
-            if (isnan(x)) {
+            if (std::isnan(x)) {
                 msg << "Got NaN in quat x coord, index " << i;
                 my_lua_error(L, msg.str());
             }
-            if (isnan(y)) {
+            if (std::isnan(y)) {
                 msg << "Got NaN in quat y coord, index " << i;
                 my_lua_error(L, msg.str());
             }
-            if (isnan(z)) {
+            if (std::isnan(z)) {
                 msg << "Got NaN in quat z coord, index " << i;
                 my_lua_error(L, msg.str());
             }

--- a/engine/lua_wrappers_core.cpp
+++ b/engine/lua_wrappers_core.cpp
@@ -25,6 +25,15 @@
     #include <google/profiler.h>
 #endif
 
+#ifndef isnan
+        static inline bool isnan(float f)
+        {
+            // std::isnan() is C99, not supported by all compilers
+            // However NaN always fails this next test, no other number does.
+            return f != f;
+        }
+#endif
+
 #ifndef WIN32
     #include <sys/mman.h>
 #endif


### PR DESCRIPTION
Every time I take new grit-engine I need to do this fix to succeed to compile on Linux Ubuntu 16.04LTS
example of error:

```
engine/lua_wrappers_core.cpp: In function ‘int global_check_nan(lua_State*)’:
engine/lua_wrappers_core.cpp:726:41: error: ‘isnan’ was not declared in this scope
             if (isnan(lua_tonumber(L, i))) {
                                         ^
engine/lua_wrappers_core.cpp:726:41: note: suggested alternative:
In file included from dependencies/grit-ogre/OgreMain/include/OgreStdHeaders.h:28:0,
                 from dependencies/grit-ogre/OgreMain/include/OgrePrerequisites.h:367,
                 from dependencies/grit-ogre/OgreMain/include/Ogre.h:31,
                 from dependencies/stdafx/stdafx.h:1:
/usr/include/c++/5/cmath:641:5: note:   ‘std::isnan’
     isnan(_Tp __x)
     ^
```
```
 gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/5/lto-wrapper
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 5.4.0-6ubuntu1~16.04.4' --with-bugurl=file:///usr/share/doc/gcc-5/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-5 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-5-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-5-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-5-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)
```