### PR TITLE
Add to devjs an attach detach status

### DIFF
--- a/engine/linux/joystick_devjs.cpp
+++ b/engine/linux/joystick_devjs.cpp
@@ -49,12 +49,12 @@ Created once after you have done the calibration, execute this script to restore
 after reboot if necessary
 
 # create
-echo "#!/bin/bash" >calibrate.sh
-jscal -p /dev/input/js0 >>calibrate.sh
-chmod +x calibrate.sh
+echo "#!/bin/bash" >joystick_calibrate.sh
+jscal -p /dev/input/js0 >>joystick_calibrate.sh
+chmod +x joystick_calibrate.sh
 
 # restore
-./calibrate.sh
+./joystick_calibrate.sh
 
 */
 
@@ -103,6 +103,7 @@ Details:
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #include <sstream>
 
@@ -135,12 +136,11 @@ bool JoystickDevjs::getEvents(std::vector<signed char> *buttons_indexes_and_valu
     if (axes_indexes) axes_indexes->clear();
     if (axes_values) axes_values->clear();
 
-    if (fd < 0) return false;
-
-    bool moved = false;
+    if (fd < 0) return false; // joystick connection state is: detached
+    int n;
 
     while (true) {
-        int n = read(fd, &event, sizeof(struct JoystickDevjsEvent));
+        n = read(fd, &event, sizeof(struct JoystickDevjsEvent));
         if (n != sizeof(struct JoystickDevjsEvent)) break;
 
         // event.type &= ~ JOYSTICK_DEVJS_EVENT_TYPE_INIT; /* discard init events */
@@ -157,7 +157,6 @@ bool JoystickDevjs::getEvents(std::vector<signed char> *buttons_indexes_and_valu
                         pushed_button_index_and_value = button_index;
                         pushed_button_index_and_value = pushed_button_index_and_value * mod;
                         buttons_indexes_and_values->push_back(pushed_button_index_and_value);
-                        moved = true;
                         // printf("B%02d:%02d:%02d\n",
                         //        button_index, event.value, pushed_button_index_and_value);
                     }
@@ -173,7 +172,6 @@ bool JoystickDevjs::getEvents(std::vector<signed char> *buttons_indexes_and_valu
                     if (axes_indexes && axes_values) {
                        axes_indexes->push_back(pushed_axe_index);
                        axes_values->push_back(pushed_axe_value);
-                       moved = true;
                        // printf("J%02d:%06d:%d\n",
                        //        pushed_axe_index, event.value, pushed_axe_value);
                     }
@@ -183,5 +181,10 @@ bool JoystickDevjs::getEvents(std::vector<signed char> *buttons_indexes_and_valu
         }
     }
 
-    return moved;
+    if( n==sizeof(struct JoystickDevjsEvent) || (n == -1 && errno==EAGAIN) ) {
+       return true; // joystick connection state is: attached 
+    }
+    else {
+       return false; // joystick connection state is: detached 
+    }
 }

--- a/engine/lua_wrappers_core.cpp
+++ b/engine/lua_wrappers_core.cpp
@@ -25,6 +25,15 @@
     #include <google/profiler.h>
 #endif
 
+#ifndef isnan
+        static inline bool isnan(float f)
+        {
+            // std::isnan() is C99, not supported by all compilers
+            // However NaN always fails this next test, no other number does.
+            return f != f;
+        }
+#endif
+
 #ifndef WIN32
     #include <sys/mman.h>
 #endif


### PR DESCRIPTION
Changed the name calibrate.sh for joystick_calibrate.sh
Replaced moved status by an attach detach status in order to detect in lua the presence or not of the gamepad/joystick.